### PR TITLE
Import scripts from Hoa/Core

### DIFF
--- a/Bin/Hoa.php
+++ b/Bin/Hoa.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+use Hoa\Console;
+use Hoa\Core;
+use Hoa\Dispatcher;
+use Hoa\Router;
+
+/**
+ * @copyright  Copyright © 2007-2015 Hoa community
+ */
+if (!defined('HOA')) {
+    $composer = [
+        dirname(__DIR__) . DIRECTORY_SEPARATOR .
+        'vendor' . DIRECTORY_SEPARATOR .
+        'autoload.php',
+        dirname(__DIR__) . DIRECTORY_SEPARATOR .
+        '..' . DIRECTORY_SEPARATOR .
+        '..' . DIRECTORY_SEPARATOR .
+        'autoload.php',
+        dirname(__DIR__) . DIRECTORY_SEPARATOR .
+        '..' . DIRECTORY_SEPARATOR .
+        '..' . DIRECTORY_SEPARATOR .
+        '..' . DIRECTORY_SEPARATOR .
+        'autoload.php'
+    ];
+    foreach ($composer as $path) {
+        if (file_exists($path)) {
+            require_once $path;
+            break;
+        }
+    }
+    if (!defined('HOA')) {
+        require_once
+            dirname(__DIR__) . DIRECTORY_SEPARATOR .
+            '..' . DIRECTORY_SEPARATOR .
+            'Core' . DIRECTORY_SEPARATOR .
+            'Core.php';
+    }
+}
+Core::enableErrorHandler();
+Core::enableExceptionHandler();
+
+/**
+ * Here we go!
+ */
+try {
+    $router = new Router\Cli();
+    $router->get(
+        'g',
+        '(?:(?<vendor>\w+)\s+)?(?<library>\w+)?(?::(?<command>\w+))?(?<_tail>.*?)',
+        'main',
+        'main',
+        [
+            'vendor'  => 'hoa',
+            'library' => 'core',
+            'command' => 'welcome'
+        ]
+    );
+    $dispatcher = new Dispatcher\ClassMethod([
+        'synchronous.call'
+            => '(:%variables.vendor:lU:)\(:%variables.library:lU:)\Bin\(:%variables.command:lU:)',
+        'synchronous.able'
+            => 'main'
+    ]);
+    $dispatcher->setKitName('Hoa\Console\Dispatcher\Kit');
+    exit((int) $dispatcher->dispatch($router));
+} catch (Core\Exception $e) {
+    $message = $e->raise(true);
+    $code    = 1;
+} catch (\Exception $e) {
+    $message = $e->getMessage();
+    $code    = 2;
+}
+
+ob_start();
+Console\Cursor::colorize('foreground(white) background(red)');
+echo $message, "\n";
+Console\Cursor::colorize('normal');
+$content = ob_get_contents();
+ob_end_clean();
+file_put_contents('php://stderr', $content);
+exit($code);

--- a/Bin/hoa
+++ b/Bin/hoa
@@ -1,0 +1,40 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Ivan Enderlin. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * @copyright  Copyright © 2007-2015 Hoa community
+ * @license    New BSD License
+ */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'Hoa.php';

--- a/Bin/hoa.bat
+++ b/Bin/hoa.bat
@@ -1,0 +1,47 @@
+@echo off
+
+REM **
+REM * Hoa
+REM *
+REM *
+REM * @license
+REM *
+REM * New BSD License
+REM *
+REM * Copyright © 2007-2015, Ivan Enderlin. All rights reserved.
+REM *
+REM * Redistribution and use in source and binary forms, with or without
+REM * modification, are permitted provided that the following conditions are met:
+REM *     * Redistributions of source code must retain the above copyright
+REM *       notice, this list of conditions and the following disclaimer.
+REM *     * Redistributions in binary form must reproduce the above copyright
+REM *       notice, this list of conditions and the following disclaimer in the
+REM *       documentation and/or other materials provided with the distribution.
+REM *     * Neither the name of the Hoa nor the names of its contributors may be
+REM *       used to endorse or promote products derived from this software without
+REM *       specific prior written permission.
+REM *
+REM * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+REM * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+REM * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+REM * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+REM * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+REM * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+REM * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+REM * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+REM * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+REM * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+REM * POSSIBILITY OF SUCH DAMAGE.
+REM **
+REM
+REM **
+REM * @copyright  Copyright © 2007-2015 Hoa community
+REM * @license    New BSD License
+REM **
+
+BREAK=ON
+set PHP="php.exe"
+set SCRIPT_DIR=%~dp0
+set HOA=%SCRIPT_DIR%Hoa.php
+
+"%PHP%" "%HOA%" %*

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,37 @@
+{
+    "name"       : "hoa/cli",
+    "description": "The Hoa\\Cli library.",
+    "type"       : "library",
+    "keywords"   : ["library", "hoa", "console", "cli"],
+    "homepage"   : "http://hoa-project.net/",
+    "license"    : "BSD-3-Clause",
+    "authors"    : [
+        {
+            "name" : "Ivan Enderlin",
+            "email": "ivan.enderlin@hoa-project.net"
+        },
+        {
+            "name"    : "Hoa community",
+            "homepage": "http://hoa-project.net/"
+        }
+    ],
+    "support": {
+        "email" : "support@lists.hoa-project.net",
+        "irc"   : "irc://irc.freenode.org/hoaproject",
+        "source": "http://git.hoa-project.net/"
+    },
+    "require": {
+        "hoa/core"      : "~2.0",
+        "hoa/console"   : "~2.0",
+        "hoa/router"    : "~2.0",
+        "hoa/dispatcher": "~0.0"
+    },
+    "config": {
+        "bin-dir": "bin/"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.x-dev"
+        }
+    }
+}


### PR DESCRIPTION
Everything seems OK to me except two things:
- I have to finish the `README.md`
- One thing does not work: I installed Hoa/Cli and its dependency this way:

```
.
├──  Cli/
├──  Console/
├──  Core/
├──  Dispatcher/
├──  Router/
├──  Stream/
└──  UString/
```

From here, when I run `Cli/Bin/hoa` I get the following error:

```
PHP Fatal error:  Class 'Hoa\Router\Cli' not found in Cli/Bin/Hoa.php on line 76
```

I'm trying to simulate a global install of Hoa. Any clue on how to fix this ?

Everything else works (when using composer).
