### PR TITLE
Add the `bin` property

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "config": {
         "bin-dir": "bin/"
     },
+    "bin"  : ["Bin/hoa"],
     "extra": {
         "branch-alias": {
             "dev-master": "1.x-dev"


### PR DESCRIPTION
This way, the `hoa` command will be available in `vendor/bin/hoa` by
default.

This has not been migrated from `Hoa\Core`.
